### PR TITLE
Updating loginform.php to remove password hash from session

### DIFF
--- a/login/includes/loginform.php
+++ b/login/includes/loginform.php
@@ -51,7 +51,6 @@ class LoginForm extends DbConn
                     session_start();
 
                     $_SESSION['username'] = $myusername;
-                    $_SESSION['password'] = $mypassword;
 
             } elseif (password_verify($mypassword, $result['password']) && $result['verified'] == '0') {
 


### PR DESCRIPTION
While the password string may be hashed, it is bad practice to save it in the session. If you need to be able to verify a user is logged in, generate a random hash for the user, save it in the db with an expiration timestamp, and use that in the session instead.