### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If the user has the right username and password, then the `checklogin.php` will 
 If the username and/or the password are wrong the `checklogin.php` will send "Wrong Username or Password".
 
 
-###Signup/Login Workflow:
+### Signup/Login Workflow:
 > 1) Create new user using `signup.php` form
 > (note: validation occurs both client and server side)
 > &nbsp;&nbsp;&nbsp;&nbsp;<b>Validation requires: </b>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
